### PR TITLE
Fixing origin error

### DIFF
--- a/lib/ueberauth/strategy/shopify/oauth.ex
+++ b/lib/ueberauth/strategy/shopify/oauth.ex
@@ -61,7 +61,6 @@ defmodule Ueberauth.Strategy.Shopify.OAuth do
 
   def get_token(client, params, headers) do
     client
-    |> put_header("Accept", "application/json")
     |> OAuth2.Strategy.AuthCode.get_token(params, headers)
   end
 end


### PR DESCRIPTION
Using Accept application json seems to fail with newer versions of dependancies. 

Unsure if its an issue with hackney or something else. These headers exist on the request anyway now, and having doubles seems to make shopify return an error